### PR TITLE
feat: Install ufw if not present

### DIFF
--- a/setup-xrdp-xfce.sh
+++ b/setup-xrdp-xfce.sh
@@ -119,7 +119,9 @@ cleanup() {
 # Function to install all necessary packages for the remote desktop
 install_packages() {
   echo "[*] Updating system and installing required packages..."
-  sudo apt-get update && sudo apt-get upgrade -y || error_exit "System update failed."
+  if ! (sudo apt-get update && sudo apt-get upgrade -y); then
+    error_exit "System update failed."
+  fi
 
   local packages_to_install=(
     xfce4
@@ -194,7 +196,9 @@ configure_xrdp() {
 
   # Enable and restart the XRDP service
   echo "Enabling and restarting XRDP service..."
-  sudo systemctl enable xrdp && sudo systemctl restart xrdp || error_exit "XRDP configuration failed."
+  if ! (sudo systemctl enable xrdp && sudo systemctl restart xrdp); then
+    error_exit "XRDP configuration failed."
+  fi
 }
 
 # Function to create a new user for RDP access
@@ -226,6 +230,13 @@ create_user() {
 configure_firewall() {
   echo "[*] Setting up UFW firewall rules..."
 
+  # Check if ufw is installed and install it if not
+  if ! command -v ufw &>/dev/null; then
+    echo "ufw is not installed. Installing..."
+    sudo apt-get update
+    sudo apt-get install -y ufw || error_exit "ufw installation failed."
+  fi
+
   # Allow RDP traffic
   if ! sudo ufw status | grep -q "${RDP_PORT}/tcp"; then
     echo "Allowing RDP traffic on port ${RDP_PORT}..."
@@ -252,7 +263,7 @@ main() {
   check_os_version
 
   # Prompt for the username, defaulting to the value of DEFAULT_USERNAME
-  read -p "Enter the username for the new RDP user [${DEFAULT_USERNAME}]: " username
+  read -r -p "Enter the username for the new RDP user [${DEFAULT_USERNAME}]: " username
   local final_username=${username:-$DEFAULT_USERNAME}
 
   show_welcome_message


### PR DESCRIPTION
If ufw is not installed, the script will now install it before attempting to configure the firewall.

This change also includes minor improvements to the script's robustness by fixing shellcheck warnings.